### PR TITLE
fix: join SelectItems XML array without commas

### DIFF
--- a/main.js
+++ b/main.js
@@ -133,7 +133,7 @@ class risPortService {
       let XML;
 
       if (Array.isArray(selectItem)) {
-        itemStr = selectItem.map((phoneName) => "<soap:item>" + "<soap:Item>" + phoneName + "</soap:Item>" + "</soap:item>");
+        itemStr = selectItem.map((phoneName) => "<soap:item>" + "<soap:Item>" + phoneName + "</soap:Item>" + "</soap:item>").join("");
       } else {
         itemStr = "<soap:item>" + "<soap:Item>" + selectItem + "</soap:Item>" + "</soap:item>";
       }
@@ -205,19 +205,19 @@ class risPortService {
       options.SOAPAction = `http://schemas.cisco.com/ast/soap/action/#RisPort#SelectCtiItem`;
 
       if (Array.isArray(appItem)) {
-        appItemsStr = appItem.map((item) => "<soap:item>" + "<soap:AppItem>" + item + "</soap:AppItem>" + "</soap:item>");
+        appItemsStr = appItem.map((item) => "<soap:item>" + "<soap:AppItem>" + item + "</soap:AppItem>" + "</soap:item>").join("");
       } else {
         appItemsStr = "<soap:item>" + "<soap:AppItem>" + appItem + "</soap:AppItem>" + "</soap:item>";
       }
 
       if (Array.isArray(devName)) {
-        devNamesStr = appItem.map((item) => "<soap:item>" + "<soap:DevName>" + item + "</soap:DevName>" + "</soap:item>");
+        devNamesStr = appItem.map((item) => "<soap:item>" + "<soap:DevName>" + item + "</soap:DevName>" + "</soap:item>").join("");
       } else {
         devNamesStr = "<soap:item>" + "<soap:DevName>" + devName + "</soap:DevName>" + "</soap:item>";
       }
 
       if (Array.isArray(dirNumber)) {
-        dirNumbersStr = dirNumber.map((item) => "<soap:item>" + "<soap:DirNumber>" + item + "</soap:DirNumber>" + "</soap:item>");
+        dirNumbersStr = dirNumber.map((item) => "<soap:item>" + "<soap:DirNumber>" + item + "</soap:DirNumber>" + "</soap:item>").join("");
       } else {
         dirNumbersStr = "<soap:item>" + "<soap:DirNumber>" + dirNumber + "</soap:DirNumber>" + "</soap:item>";
       }


### PR DESCRIPTION
## Summary

- When arrays are passed to `selectCmDevice()` or `selectCtiDevice()`, the `.map()` calls produce JavaScript arrays for `SelectItems`, `AppItems`, `DevNames`, and `DirNumbers`.
- These arrays are then interpolated via `util.format('%s', ...)`, which calls `Array.toString()` under the hood, joining elements with commas (e.g. `<soap:item>...</soap:item>,<soap:item>...</soap:item>`).
- The commas produce invalid XML, causing CUCM to silently ignore most items in the selection criteria.
- The fix adds `.join("")` after each `.map()` call so elements are concatenated without a delimiter, producing valid XML.

Fixes #1

## Test plan

- [ ] Pass a multi-element array to `selectCmDevice()` and verify the SOAP XML contains no commas between `<soap:item>` elements
- [ ] Pass a multi-element array to `selectCtiDevice()` for `appItem`, `devName`, and `dirNumber` and verify the same
- [ ] Confirm single-string (non-array) arguments still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)